### PR TITLE
Fix fixed frame in RViz config

### DIFF
--- a/src/lerobot_description/rviz/display.rviz
+++ b/src/lerobot_description/rviz/display.rviz
@@ -106,7 +106,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: Base
+    Fixed Frame: base
     Frame Rate: 30
   Name: root
   Tools:

--- a/src/lerobot_moveit/config/moveit.rviz
+++ b/src/lerobot_moveit/config/moveit.rviz
@@ -106,7 +106,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: Base
+    Fixed Frame: base
     Frame Rate: 30
   Name: root
   Tools:


### PR DESCRIPTION
`base` should be all lower-case, otherwise I get this error: `Frame [Base] does not exist`

<img width="491" height="559" alt="Screenshot from 2025-07-30 22-12-44" src="https://github.com/user-attachments/assets/a21fb3c6-77cc-4413-8f25-7031915e0c76" />
